### PR TITLE
Config CORS for any URL (Temporary)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -12,23 +12,26 @@ dotenv.config();
 const main = async () => {
     const app = express();
     const PORT = process.env.PORT || 35001;
-    const FRONT_URL = process.env.FRONT_URL || 'http://127.0.0.1:5173';
+    // Advertencia:  comentar esta linea cuando este deplegado front
+    app.use(cors());
+    //Advertencia: Descomentar cuando ya este el front delplegado (SEGURIDAD CORS)
+    // const FRONT_URL = process.env.FRONT_URL || 'http://127.0.0.1:5173';
 
-    app.use((req, res, next) => {
-        console.log('Origin:', req.headers.origin);
-        next();
-    });
+    // app.use((req, res, next) => {
+    //     console.log('Origin:', req.headers.origin);
+    //     next();
+    // });
     
 
-    app.use(json({ limit: "50mb" }));
-    app.use(
-        cors({
-            origin: [FRONT_URL,"http://localhost:5173", "*"],
-            methods: ['GET', 'POST', 'PUT', 'DELETE'],
-            allowedHeaders: ['Content-Type', 'Authorization'], 
-            credentials: true, // Necesario si envías cookies o autorizaciones
-        })
-    );
+    // app.use(json({ limit: "50mb" }));
+    // app.use(
+    //     cors({
+    //         origin: [FRONT_URL,"http://localhost:5173", "*"],
+    //         methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    //         allowedHeaders: ['Content-Type', 'Authorization'], 
+    //         credentials: true, // Necesario si envías cookies o autorizaciones
+    //     })
+    // );
     // Manejar solicitudes preflight (OPTIONS)
     app.options('*', cors());
 


### PR DESCRIPTION
Añadí una configuracion temporal para que cualquier URL (Origen) pueda hacer peticiones al API (Seguridad CORS) mientras se despliega el Frontend por completo. Por motivos de seguridad solo será temporal. 